### PR TITLE
Moving where the RabbitMQ ack is to after the message is processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.6] - TBD
+## [1.3.6] - 2021-5-12
 
 ### Added in 1.3.6
 
 - Exposing RabbitMQ virtual host as a settable parameter.
+- If the connection to the RabbitMQ exchange/server is lost, redoer now attempts to reconnect.
+- Reading redo records from RabbitMQ is now more robust against record loss if a container goes down unexpectedly.
 
 ## [1.3.5] - 2021-02-18
 


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #34 

## Why was change needed

Records could be lost if the container crashed/hanged